### PR TITLE
feat(devportal-platform): vkdr devportal-platform install (DevPortal V2)

### DIFF
--- a/src/main/java/codes/vee/vkdr/cmd/VkdrCommand.java
+++ b/src/main/java/codes/vee/vkdr/cmd/VkdrCommand.java
@@ -3,6 +3,7 @@ package codes.vee.vkdr.cmd;
 import codes.vee.vkdr.cmd.common.SilentMixin;
 import codes.vee.vkdr.cmd.crossplane.VkdrCrossplaneCommand;
 import codes.vee.vkdr.cmd.devportal.VkdrDevPortalCommand;
+import codes.vee.vkdr.cmd.devportal_platform.VkdrDevPortalPlatformCommand;
 import codes.vee.vkdr.cmd.keycloak.VkdrKeycloakCommand;
 import codes.vee.vkdr.cmd.kong.VkdrKongCommand;
 import codes.vee.vkdr.cmd.nginx.VkdrNginxCommand;
@@ -44,6 +45,7 @@ import picocli.CommandLine.Mixin;
                 VkdrPostgresCommand.class,
                 VkdrKongCommand.class,
                 VkdrDevPortalCommand.class,
+                VkdrDevPortalPlatformCommand.class,
                 VkdrKeycloakCommand.class,
                 VkdrWhoamiCommand.class,
                 VkdrVaultCommand.class,

--- a/src/main/java/codes/vee/vkdr/cmd/common/ExitCodes.java
+++ b/src/main/java/codes/vee/vkdr/cmd/common/ExitCodes.java
@@ -1,4 +1,4 @@
-// NEXT: 200
+// NEXT: 210
 package codes.vee.vkdr.cmd.common;
 
 public final class ExitCodes {
@@ -117,6 +117,12 @@ public final class ExitCodes {
     public static final int CROSSPLANE_BASE = 190;
     public static final int CROSSPLANE_REMOVE = 201;
     public static final int CROSSPLANE_INSTALL = 191;
+
+    // DevPortal Platform (V2) related exit codes (200-209)
+    public static final int DEVPORTAL_PLATFORM_BASE = 200;
+    public static final int DEVPORTAL_PLATFORM_INSTALL = 201;
+    public static final int DEVPORTAL_PLATFORM_REMOVE = 202;
+    public static final int DEVPORTAL_PLATFORM_EXPLAIN = 203;
 
     // ADD_HERE
 }

--- a/src/main/java/codes/vee/vkdr/cmd/devportal_platform/VkdrDevPortalPlatformCommand.java
+++ b/src/main/java/codes/vee/vkdr/cmd/devportal_platform/VkdrDevPortalPlatformCommand.java
@@ -1,0 +1,16 @@
+package codes.vee.vkdr.cmd.devportal_platform;
+
+import codes.vee.vkdr.cmd.common.ExitCodes;
+import org.springframework.stereotype.Component;
+import picocli.CommandLine;
+
+@Component
+@CommandLine.Command(name = "devportal-platform", mixinStandardHelpOptions = true,
+        exitCodeOnExecutionException = ExitCodes.DEVPORTAL_PLATFORM_BASE,
+        description = "manage VeeCode DevPortal V2 (the devportal-platform image line, presets-based)",
+        subcommands = {
+            VkdrDevPortalPlatformInstallCommand.class,
+            VkdrDevPortalPlatformRemoveCommand.class
+        })
+public class VkdrDevPortalPlatformCommand {
+}

--- a/src/main/java/codes/vee/vkdr/cmd/devportal_platform/VkdrDevPortalPlatformInstallCommand.java
+++ b/src/main/java/codes/vee/vkdr/cmd/devportal_platform/VkdrDevPortalPlatformInstallCommand.java
@@ -1,0 +1,94 @@
+package codes.vee.vkdr.cmd.devportal_platform;
+
+import codes.vee.vkdr.ShellExecutor;
+import codes.vee.vkdr.cmd.common.CommonDomainMixin;
+import codes.vee.vkdr.cmd.common.ExitCodes;
+import org.springframework.stereotype.Component;
+import picocli.CommandLine;
+
+import java.util.concurrent.Callable;
+
+@Component
+@CommandLine.Command(name = "install", mixinStandardHelpOptions = true,
+        description = "install VeeCode DevPortal V2 (presets-based; requires Kong Gateway as ingress)",
+        exitCodeOnExecutionException = ExitCodes.DEVPORTAL_PLATFORM_INSTALL)
+class VkdrDevPortalPlatformInstallCommand implements Callable<Integer> {
+
+    @CommandLine.Mixin
+    private CommonDomainMixin domainSecure;
+
+    @CommandLine.Option(names = {"--presets"},
+            defaultValue = "recommended",
+            description = "Comma-separated VEECODE_PRESETS (default: recommended). 'github'/'github-auth'/'kubernetes' are auto-added when their flags/credentials are provided.")
+    private String presets;
+
+    @CommandLine.Option(names = {"--github-pat", "--github_pat"},
+            defaultValue = "",
+            description = "GitHub Personal Access Token — adds the 'github' preset (needs --github-org too)")
+    private String githubPat;
+
+    @CommandLine.Option(names = {"--github-org", "--github_org"},
+            defaultValue = "",
+            description = "GitHub organization — for the 'github' preset")
+    private String githubOrg;
+
+    @CommandLine.Option(names = {"--github-auth-client-id", "--github_auth_client_id"},
+            defaultValue = "",
+            description = "GitHub OAuth App client id — adds the 'github-auth' sign-in preset")
+    private String githubAuthClientId;
+
+    @CommandLine.Option(names = {"--github-auth-client-secret", "--github_auth_client_secret"},
+            defaultValue = "",
+            description = "GitHub OAuth App client secret — for the 'github-auth' preset")
+    private String githubAuthClientSecret;
+
+    @CommandLine.Option(names = {"--with-kubernetes", "--with_kubernetes"},
+            defaultValue = "false",
+            description = "Enable the kubernetes preset against the in-cluster API (VKDR creates a read-only SA + token) (default: false)")
+    private boolean withKubernetes;
+
+    @CommandLine.Option(names = {"--plugin-registry", "--plugin_registry"},
+            defaultValue = "",
+            description = "OCI registry mirror for dynamic plugins (sets PLUGIN_REGISTRY)")
+    private String pluginRegistry;
+
+    @CommandLine.Option(names = {"--samples", "--install-samples", "--install_samples"},
+            defaultValue = "false",
+            description = "Install apps from the sample catalog (default: false)")
+    private boolean installSamples;
+
+    @CommandLine.Option(names = {"--location"},
+            defaultValue = "",
+            description = "Extra Backstage catalog location (URL)")
+    private String location;
+
+    @CommandLine.Option(names = {"--merge", "--merge-values"},
+            defaultValue = "",
+            description = "Values file (V2 chart surface) to merge over the defaults (optional)")
+    private String mergeValues;
+
+    @CommandLine.Option(names = {"--load-env", "--load_env"},
+            defaultValue = "false",
+            description = "Load GitHub credentials from environment variables (default: false)")
+    private boolean loadEnv;
+
+    @Override
+    public Integer call() throws Exception {
+        return ShellExecutor.executeCommand(
+                "devportal-platform/install",
+                domainSecure.domain,
+                String.valueOf(domainSecure.enable_https),
+                presets,
+                githubPat,
+                githubOrg,
+                githubAuthClientId,
+                githubAuthClientSecret,
+                String.valueOf(withKubernetes),
+                pluginRegistry,
+                String.valueOf(installSamples),
+                location,
+                mergeValues,
+                String.valueOf(loadEnv)
+        );
+    }
+}

--- a/src/main/java/codes/vee/vkdr/cmd/devportal_platform/VkdrDevPortalPlatformRemoveCommand.java
+++ b/src/main/java/codes/vee/vkdr/cmd/devportal_platform/VkdrDevPortalPlatformRemoveCommand.java
@@ -1,0 +1,20 @@
+package codes.vee.vkdr.cmd.devportal_platform;
+
+import codes.vee.vkdr.ShellExecutor;
+import codes.vee.vkdr.cmd.common.ExitCodes;
+import org.springframework.stereotype.Component;
+import picocli.CommandLine;
+
+import java.util.concurrent.Callable;
+
+@Component
+@CommandLine.Command(name = "remove", mixinStandardHelpOptions = true,
+        description = "remove VeeCode DevPortal V2",
+        exitCodeOnExecutionException = ExitCodes.DEVPORTAL_PLATFORM_REMOVE)
+class VkdrDevPortalPlatformRemoveCommand implements Callable<Integer> {
+
+    @Override
+    public Integer call() throws Exception {
+        return ShellExecutor.executeCommand("devportal-platform/remove");
+    }
+}

--- a/src/main/resources/formulas/_shared/values/devportal-platform-common.yaml
+++ b/src/main/resources/formulas/_shared/values/devportal-platform-common.yaml
@@ -1,0 +1,18 @@
+# Base values VKDR injects into the veecode-devportal-platform chart (DevPortal V2).
+# The install formula overrides presets, existingSecret, ingress host, pluginRegistry
+# and appConfig.catalog.locations at runtime. SQLite-on-PVC persistence + image tag
+# come from the chart defaults (do not pin them here).
+presets:
+  - recommended
+existingSecret: ""
+ingress:
+  enabled: true
+  className: kong
+  hosts:
+    - host: devportal.localhost
+      paths:
+        - path: /
+          pathType: Prefix
+appConfig:
+  catalog:
+    locations: []

--- a/src/main/resources/formulas/devportal-platform/_meta/spec.md
+++ b/src/main/resources/formulas/devportal-platform/_meta/spec.md
@@ -1,0 +1,36 @@
+# devportal-platform Formula Specification
+
+Installs **VeeCode DevPortal V2** (the `devportal-platform` image line) from the published
+`veecode-devportal-platform` Helm chart. Separate from the V1 `devportal` formula, which
+stays as-is for the 1.x distro.
+
+## Purpose
+
+Deploy DevPortal V2 on a local VKDR cluster using the V2 runtime contract: **presets**
+(`VEECODE_PRESETS`) instead of V1 profiles, a VKDR-managed credentials Secret consumed via
+the chart's `existingSecret`, Kong ingress, and persistent SQLite (chart default).
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `install/formula.sh` | Compose presets, build the credentials Secret, install the chart from the next-charts Helm repo |
+| `remove/formula.sh` | Remove the release + VKDR-owned Secret and kubernetes-preset RBAC |
+| `_shared/values/devportal-platform-common.yaml` | V2-surface Helm values template |
+
+## Behaviour
+
+- `--presets` sets the base list; `github` / `github-auth` / `kubernetes` are auto-added
+  when their credentials/flags are provided.
+- GitHub is PAT + OAuth only (no GitHub App): `--github-pat` + `--github-org` → `github`
+  preset; `--github-auth-client-id` + `--github-auth-client-secret` → `github-auth` preset.
+- `--with-kubernetes` makes VKDR create a read-only ServiceAccount + ClusterRole + token
+  (chart `rbac.clusterRoles.create` stays false) and wires `K8S_CLUSTER_*` into the Secret.
+- Credentials live only in a VKDR-created Secret (referenced via `existingSecret`), never
+  in the Helm release values.
+- Missing required preset variables fail the boot fast (exit 78) — not masked.
+
+## Version sync
+
+The chart pins the image; this formula consumes whatever chart version is published. See the
+chart's `RELEASE.md` for the image↔chart version-sync rule.

--- a/src/main/resources/formulas/devportal-platform/_meta/update.yaml
+++ b/src/main/resources/formulas/devportal-platform/_meta/update.yaml
@@ -1,0 +1,7 @@
+# Update configuration for automated dependency updates
+type: helm-latest
+helm:
+  repo: https://veecode-platform.github.io/next-charts
+  chart: veecode-devportal-platform
+  values_file: _shared/values/devportal-platform-common.yaml
+test: make test-formula formula=devportal-platform

--- a/src/main/resources/formulas/devportal-platform/install/formula.sh
+++ b/src/main/resources/formulas/devportal-platform/install/formula.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+
+# vkdr devportal-platform install — installs DevPortal V2 (presets-based) from the
+# published veecode-devportal-platform Helm chart. Distinct from `vkdr devportal install`
+# (V1). Args are positional, passed by VkdrDevPortalPlatformInstallCommand.
+
+VKDR_ENV_DOMAIN=$1
+VKDR_ENV_SECURE=$2
+VKDR_ENV_PRESETS=$3
+VKDR_ENV_GITHUB_PAT=$4
+VKDR_ENV_GITHUB_ORG=$5
+VKDR_ENV_GITHUB_AUTH_CLIENT_ID=$6
+VKDR_ENV_GITHUB_AUTH_CLIENT_SECRET=$7
+VKDR_ENV_WITH_KUBERNETES=$8
+VKDR_ENV_PLUGIN_REGISTRY=$9
+VKDR_ENV_INSTALL_SAMPLES=${10}
+VKDR_ENV_LOCATION=${11}
+VKDR_ENV_MERGE_VALUES=${12}
+VKDR_ENV_LOAD_ENV=${13}
+
+FORMULA_DIR="$(dirname "$0")"
+SHARED_DIR="$FORMULA_DIR/../../_shared"
+META_DIR="$FORMULA_DIR/../_meta"
+
+source "$SHARED_DIR/lib/tools-versions.sh"
+source "$SHARED_DIR/lib/tools-paths.sh"
+source "$SHARED_DIR/lib/log.sh"
+source "$SHARED_DIR/lib/ingress-tools.sh"
+source "$SHARED_DIR/lib/docker-tools.sh"
+
+VKDR_VALUES_SRC="$SHARED_DIR/values/devportal-platform-common.yaml"
+VKDR_VALUES="/tmp/devportal-platform.yaml"
+DEVPORTAL_NAMESPACE=platform
+RELEASE_NAME=veecode-devportal-platform
+CHART_NAME=veecode-devportal-platform
+CHART_REPO="https://veecode-platform.github.io/next-charts"
+SECRET_NAME=devportal-platform-secrets
+K8S_SA_NAME=veecode-devportal-platform-k8s-reader
+
+# overridden by detectClusterPorts
+VKDR_HTTP_PORT=8000
+VKDR_HTTPS_PORT=8001
+VKDR_FINAL_PRESETS=""
+VKDR_K8S_TOKEN=""
+
+prepareEnv() {
+  if [[ "$VKDR_ENV_LOAD_ENV" == "true" ]]; then
+    debug "prepareEnv: loading GitHub credentials from environment"
+    [ -z "$VKDR_ENV_GITHUB_PAT" ] && [ -n "$GITHUB_PAT" ] && VKDR_ENV_GITHUB_PAT="$GITHUB_PAT"
+    [ -z "$VKDR_ENV_GITHUB_ORG" ] && [ -n "$GITHUB_ORG" ] && VKDR_ENV_GITHUB_ORG="$GITHUB_ORG"
+    [ -z "$VKDR_ENV_GITHUB_AUTH_CLIENT_ID" ] && [ -n "$GITHUB_AUTH_CLIENT_ID" ] && VKDR_ENV_GITHUB_AUTH_CLIENT_ID="$GITHUB_AUTH_CLIENT_ID"
+    [ -z "$VKDR_ENV_GITHUB_AUTH_CLIENT_SECRET" ] && [ -n "$GITHUB_AUTH_CLIENT_SECRET" ] && VKDR_ENV_GITHUB_AUTH_CLIENT_SECRET="$GITHUB_AUTH_CLIENT_SECRET"
+  fi
+}
+
+# Final preset list = --presets + auto-added presets whose credentials/flags are present.
+# Dedup, preserve order. (github needs PAT+ORG; github-auth needs the OAuth pair.)
+composePresets() {
+  local list="$VKDR_ENV_PRESETS"
+  if [ -n "$VKDR_ENV_GITHUB_PAT" ] && [ -n "$VKDR_ENV_GITHUB_ORG" ]; then list="$list,github"; fi
+  if [ -n "$VKDR_ENV_GITHUB_AUTH_CLIENT_ID" ] && [ -n "$VKDR_ENV_GITHUB_AUTH_CLIENT_SECRET" ]; then list="$list,github-auth"; fi
+  if [ "$VKDR_ENV_WITH_KUBERNETES" == "true" ]; then list="$list,kubernetes"; fi
+  VKDR_FINAL_PRESETS=$(echo "$list" | tr ',' '\n' | awk 'NF && !seen[$0]++' | paste -sd, -)
+}
+
+startInfos() {
+  boldInfo "DevPortal V2 (devportal-platform) Install"
+  bold "=============================="
+  boldNotice "Domain: $VKDR_ENV_DOMAIN"
+  boldNotice "Presets: $VKDR_FINAL_PRESETS"
+  boldNotice "With kubernetes preset: $VKDR_ENV_WITH_KUBERNETES"
+  [ -n "$VKDR_ENV_GITHUB_ORG" ] && boldNotice "GitHub org: $VKDR_ENV_GITHUB_ORG"
+  [ -n "$VKDR_ENV_PLUGIN_REGISTRY" ] && boldNotice "Plugin registry: $VKDR_ENV_PLUGIN_REGISTRY"
+  boldNotice "Install samples: $VKDR_ENV_INSTALL_SAMPLES"
+  bold "=============================="
+}
+
+checkForKong() {
+  if $VKDR_HELM list -n vkdr | grep -q "^kong"; then
+    debug "checkForKong: Kong already installed."
+    return 0
+  fi
+  debug "checkForKong: installing Kong as default ingress controller"
+  ( vkdr kong install --default-ic -t "3.9.1" -m standard )
+}
+
+createDevPortalNamespace() {
+  echo "
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: $DEVPORTAL_NAMESPACE
+" | $VKDR_KUBECTL apply -f -
+}
+
+# When --with-kubernetes: VKDR owns the RBAC (chart's rbac.clusterRoles.create stays
+# false). Create a read-only SA + ClusterRole + binding and mint a long-lived token
+# the kubernetes preset consumes via K8S_CLUSTER_TOKEN.
+setupKubernetesSA() {
+  debug "setupKubernetesSA: creating read-only SA + ClusterRole for the kubernetes preset"
+  echo "
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: $K8S_SA_NAME
+  namespace: $DEVPORTAL_NAMESPACE
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: $K8S_SA_NAME
+rules:
+  - apiGroups: [\"\"]
+    resources: [configmaps, limitranges, namespaces, nodes, pods, resourcequotas, services]
+    verbs: [get, list, watch]
+  - apiGroups: [\"apps\"]
+    resources: [daemonsets, deployments, replicasets, statefulsets]
+    verbs: [get, list, watch]
+  - apiGroups: [\"autoscaling\"]
+    resources: [horizontalpodautoscalers]
+    verbs: [get, list, watch]
+  - apiGroups: [\"networking.k8s.io\"]
+    resources: [ingresses, ingressclasses]
+    verbs: [get, list, watch]
+  - apiGroups: [\"batch\"]
+    resources: [jobs, cronjobs]
+    verbs: [get, list, watch]
+  - apiGroups: [\"metrics.k8s.io\"]
+    resources: [pods]
+    verbs: [get, list]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: $K8S_SA_NAME
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: $K8S_SA_NAME
+subjects:
+  - kind: ServiceAccount
+    name: $K8S_SA_NAME
+    namespace: $DEVPORTAL_NAMESPACE
+" | $VKDR_KUBECTL apply -f -
+  VKDR_K8S_TOKEN=$($VKDR_KUBECTL create token "$K8S_SA_NAME" -n "$DEVPORTAL_NAMESPACE" --duration=87600h)
+}
+
+# VKDR-managed credentials Secret consumed by the chart via existingSecret (envFrom).
+# Keeps secrets out of the Helm release. Only sets the vars actually provided.
+createSecret() {
+  debug "createSecret: building $SECRET_NAME from provided credentials"
+  local args=()
+  [ -n "$VKDR_ENV_GITHUB_PAT" ] && args+=("--from-literal=GITHUB_PAT=$VKDR_ENV_GITHUB_PAT")
+  [ -n "$VKDR_ENV_GITHUB_ORG" ] && args+=("--from-literal=GITHUB_ORG=$VKDR_ENV_GITHUB_ORG")
+  [ -n "$VKDR_ENV_GITHUB_AUTH_CLIENT_ID" ] && args+=("--from-literal=GITHUB_AUTH_CLIENT_ID=$VKDR_ENV_GITHUB_AUTH_CLIENT_ID")
+  [ -n "$VKDR_ENV_GITHUB_AUTH_CLIENT_SECRET" ] && args+=("--from-literal=GITHUB_AUTH_CLIENT_SECRET=$VKDR_ENV_GITHUB_AUTH_CLIENT_SECRET")
+  if [ "$VKDR_ENV_WITH_KUBERNETES" == "true" ]; then
+    setupKubernetesSA
+    args+=("--from-literal=K8S_CLUSTER_NAME=vkdr-local")
+    args+=("--from-literal=K8S_CLUSTER_URL=https://kubernetes.default.svc")
+    args+=("--from-literal=K8S_CLUSTER_TOKEN=$VKDR_K8S_TOKEN")
+  fi
+  $VKDR_KUBECTL create secret generic "$SECRET_NAME" -n "$DEVPORTAL_NAMESPACE" "${args[@]}" \
+    --dry-run=client -o yaml | $VKDR_KUBECTL apply -f -
+}
+
+settingValues() {
+  cp "$VKDR_VALUES_SRC" "$VKDR_VALUES"
+}
+
+patchValues() {
+  $VKDR_YQ eval ".presets = (\"$VKDR_FINAL_PRESETS\" | split(\",\"))" -i "$VKDR_VALUES"
+  $VKDR_YQ eval ".existingSecret = \"$SECRET_NAME\"" -i "$VKDR_VALUES"
+  $VKDR_YQ eval ".ingress.hosts[0].host = \"devportal.$VKDR_ENV_DOMAIN\"" -i "$VKDR_VALUES"
+  if [ -n "$VKDR_ENV_PLUGIN_REGISTRY" ]; then
+    $VKDR_YQ eval ".pluginRegistry = \"$VKDR_ENV_PLUGIN_REGISTRY\"" -i "$VKDR_VALUES"
+  fi
+  # Catalog locations (always at least the vkdr demo catalog, like V1)
+  local loc="https://github.com/veecode-platform/vkdr-catalog/blob/main/catalog-info.yaml"
+  if [ "$VKDR_ENV_INSTALL_SAMPLES" == "true" ]; then
+    loc="https://github.com/veecode-platform/vkdr-catalog/blob/main/catalog-info-samples.yaml"
+  fi
+  $VKDR_YQ eval ".appConfig.catalog.locations += [{\"type\":\"url\",\"target\":\"$loc\"}]" -i "$VKDR_VALUES"
+  if [ -n "$VKDR_ENV_LOCATION" ]; then
+    $VKDR_YQ eval ".appConfig.catalog.locations += [{\"type\":\"url\",\"target\":\"$VKDR_ENV_LOCATION\"}]" -i "$VKDR_VALUES"
+  fi
+}
+
+mergeValues() {
+  if [ -z "$VKDR_ENV_MERGE_VALUES" ]; then return; fi
+  debug "mergeValues: merging $VKDR_ENV_MERGE_VALUES"
+  $VKDR_YQ eval-all -i 'select(fileIndex == 0) *+ select(fileIndex == 1)' "$VKDR_VALUES" "$VKDR_ENV_MERGE_VALUES"
+}
+
+installDevPortal() {
+  debug "installDevPortal: helm upgrade --install $RELEASE_NAME from $CHART_REPO"
+  $VKDR_HELM upgrade "$RELEASE_NAME" "$CHART_NAME" --install --wait --timeout 10m \
+    --repo "$CHART_REPO" --create-namespace -n "$DEVPORTAL_NAMESPACE" \
+    -f "$VKDR_VALUES"
+}
+
+installSampleApps() {
+  if [ "$VKDR_ENV_INSTALL_SAMPLES" != "true" ]; then return; fi
+  debug "installSampleApps: applying sample apps"
+  $VKDR_KUBECTL apply -f "$SHARED_DIR/sample-apps/petclinic.yaml" -n vkdr
+  $VKDR_KUBECTL apply -f "$SHARED_DIR/sample-apps/viacep-api.yaml" -n vkdr
+}
+
+runFormula() {
+  detectClusterPorts
+  prepareEnv
+  composePresets
+  startInfos
+  checkDockerEngine
+  checkForKong
+  createDevPortalNamespace
+  createSecret
+  settingValues
+  patchValues
+  mergeValues
+  installDevPortal
+  installSampleApps
+}
+
+runFormula

--- a/src/main/resources/formulas/devportal-platform/remove/formula.sh
+++ b/src/main/resources/formulas/devportal-platform/remove/formula.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# vkdr devportal-platform remove — uninstalls the DevPortal V2 release.
+
+FORMULA_DIR="$(dirname "$0")"
+SHARED_DIR="$FORMULA_DIR/../../_shared"
+
+source "$SHARED_DIR/lib/tools-versions.sh"
+source "$SHARED_DIR/lib/tools-paths.sh"
+source "$SHARED_DIR/lib/log.sh"
+
+DEVPORTAL_NAMESPACE=platform
+RELEASE_NAME=veecode-devportal-platform
+SECRET_NAME=devportal-platform-secrets
+K8S_SA_NAME=veecode-devportal-platform-k8s-reader
+
+startInfos() {
+  boldInfo "DevPortal V2 (devportal-platform) Remove"
+  bold "=============================="
+}
+
+remove() {
+  $VKDR_HELM delete "$RELEASE_NAME" -n "$DEVPORTAL_NAMESPACE" 2>/dev/null || debug "remove: release not found"
+  $VKDR_KUBECTL delete secret "$SECRET_NAME" -n "$DEVPORTAL_NAMESPACE" --ignore-not-found=true
+  # VKDR-owned kubernetes-preset RBAC (cluster-scoped), if it was created
+  $VKDR_KUBECTL delete clusterrolebinding "$K8S_SA_NAME" --ignore-not-found=true
+  $VKDR_KUBECTL delete clusterrole "$K8S_SA_NAME" --ignore-not-found=true
+  $VKDR_KUBECTL delete serviceaccount "$K8S_SA_NAME" -n "$DEVPORTAL_NAMESPACE" --ignore-not-found=true
+}
+
+runFormula() {
+  startInfos
+  remove
+}
+
+runFormula

--- a/src/test/bats/formulas/devportal-platform/install.bats
+++ b/src/test/bats/formulas/devportal-platform/install.bats
@@ -1,0 +1,112 @@
+#!/usr/bin/env bats
+# install.bats - Tests for: vkdr devportal-platform install (DevPortal V2)
+#
+# Validates the V2 (presets-based) install from the published
+# veecode-devportal-platform Helm chart. Separate from the V1 devportal tests.
+#
+# PREREQUISITES:
+#   - VKDR tools installed (vkdr init)
+#   - VKDR k3d cluster running (vkdr infra up)
+
+load '../../helpers/common'
+
+DEVPORTAL_NAMESPACE="platform"
+RELEASE="veecode-devportal-platform"
+SECRET="devportal-platform-secrets"
+
+# ============================================================================
+# Setup & Teardown
+# ============================================================================
+
+setup_file() {
+  load_vkdr
+  configure_detik "$DEVPORTAL_NAMESPACE"
+
+  if ! require_vkdr_cluster; then
+    skip "VKDR cluster not available"
+  fi
+
+  $VKDR_HELM delete "$RELEASE" -n $DEVPORTAL_NAMESPACE 2>/dev/null || true
+  $VKDR_KUBECTL delete secret "$SECRET" -n $DEVPORTAL_NAMESPACE --ignore-not-found=true 2>/dev/null || true
+  sleep 3
+}
+
+teardown_file() {
+  if [ "${VKDR_SKIP_TEARDOWN:-}" != "true" ]; then
+    $VKDR_HELM delete "$RELEASE" -n $DEVPORTAL_NAMESPACE 2>/dev/null || true
+    $VKDR_KUBECTL delete secret "$SECRET" -n $DEVPORTAL_NAMESPACE --ignore-not-found=true 2>/dev/null || true
+  fi
+}
+
+# ============================================================================
+# Prerequisite Tests
+# ============================================================================
+
+@test "prerequisite: vkdr tools are installed" {
+  run check_vkdr_tools
+  assert_success
+}
+
+@test "prerequisite: vkdr cluster is running" {
+  run check_vkdr_cluster
+  assert_success
+}
+
+# ============================================================================
+# Installation Tests
+# ============================================================================
+
+@test "devportal-platform install: installs DevPortal V2 (core presets, no credentials)" {
+  # Default presets (recommended) require no credentials; installs with --wait.
+  run vkdr devportal-platform install
+  assert_success
+}
+
+@test "devportal-platform install: namespace is created" {
+  run $VKDR_KUBECTL get namespace $DEVPORTAL_NAMESPACE
+  assert_success
+}
+
+@test "devportal-platform install: helm release exists" {
+  run wait_for_helm_release "$DEVPORTAL_NAMESPACE" "$RELEASE" 300
+  assert_success
+}
+
+@test "devportal-platform install: deployment is created" {
+  local max_wait=120
+  local waited=0
+  while [ $waited -lt $max_wait ]; do
+    if $VKDR_KUBECTL get deployment -n $DEVPORTAL_NAMESPACE -l app.kubernetes.io/name=veecode-devportal-platform 2>/dev/null | grep -q "veecode-devportal-platform"; then
+      break
+    fi
+    sleep 5
+    waited=$((waited + 5))
+  done
+
+  run $VKDR_KUBECTL get deployment -n $DEVPORTAL_NAMESPACE -l app.kubernetes.io/name=veecode-devportal-platform
+  assert_success
+}
+
+@test "devportal-platform install: credentials secret is created" {
+  run $VKDR_KUBECTL get secret "$SECRET" -n $DEVPORTAL_NAMESPACE
+  assert_success
+}
+
+@test "devportal-platform install: pod answers /healthcheck (200)" {
+  # The install runs with --wait, so the pod should be Ready by now.
+  local pod
+  pod=$($VKDR_KUBECTL get pod -n $DEVPORTAL_NAMESPACE -l app.kubernetes.io/name=veecode-devportal-platform -o name | head -1)
+  [ -n "$pod" ]
+  run $VKDR_KUBECTL exec "$pod" -n $DEVPORTAL_NAMESPACE -c devportal -- curl -s -o /dev/null -w '%{http_code}' localhost:7007/healthcheck
+  assert_output "200"
+}
+
+@test "devportal-platform install: kong ingress controller present" {
+  run $VKDR_HELM list -n vkdr -q
+  assert_output --partial "kong"
+}
+
+@test "devportal-platform install: ingress is created" {
+  run $VKDR_KUBECTL get ingress -n $DEVPORTAL_NAMESPACE
+  assert_success
+}


### PR DESCRIPTION
## What

New command group **`vkdr devportal-platform`** (`install` + `remove`), sibling to the V1 `vkdr devportal` group, which is **left untouched** (still installs the 1.x distro). Installs the published **`veecode-devportal-platform`** Helm chart (DevPortal V2) using the V2 runtime surface.

This is the VKDR side of "make V2 install consume the new chart", mirroring the V1 topology (image and chart in separate repos; VKDR/docs consume the published chart).

## V1 → V2 mapping (the chart surface is entirely different)

| V1 `devportal install` | V2 `devportal-platform install` |
| --- | --- |
| `--profile` + `VEECODE_PROFILE` in `backstage-secrets` | `--presets` → `VEECODE_PRESETS` (V2 ignores PROFILE); `github`/`github-auth`/`kubernetes` auto-composed from the flags/creds provided |
| `GITHUB_TOKEN`, GitHub App (`APP_ID`/private key) | `GITHUB_PAT` + OAuth (`GITHUB_AUTH_CLIENT_ID/SECRET`) only — no GitHub App (matches the V2 presets) |
| secret mounted directly | VKDR-created Secret consumed via the chart's `existingSecret` (kept out of the Helm release) |
| `upstream.backstage.appConfig.catalog.locations` | `appConfig.catalog.locations` |
| npmrc secret | `--plugin-registry` → `PLUGIN_REGISTRY` (OCI) |
| `global.host/port/protocol` + Kong | `ingress.*` (className kong) + Kong (reused) |
| SA token for k8s plugin (always) | `--with-kubernetes`: VKDR creates a read-only SA + ClusterRole + token, wires `K8S_CLUSTER_*` (chart `rbac.clusterRoles.create` stays false) |

## Files

- `cmd/devportal_platform/` — picocli/Spring command group (install + remove); registered on `VkdrCommand`; new exit codes 200–203.
- `formulas/devportal-platform/{install,remove}/formula.sh` + `_meta`.
- `formulas/_shared/values/devportal-platform-common.yaml` — V2 values template.
- `test/bats/formulas/devportal-platform/install.bats`.

## Verification status

**Verified:**
- Formula value-mapping (preset composition + dedup + yq patching) produces values that **render correctly against the published chart** (`helm template next-charts/veecode-devportal-platform -f <generated>` → VEECODE_PRESETS, envFrom secret, ingress host, catalog location all correct).
- The chart itself, installed from the published repo, reaches **Ready + `/healthcheck` 200**, and a missing required preset var fails the boot with **exit 78** (not masked) — verified end-to-end on k3d in the chart PR. The formula's `helm install` is that same install.

**Pending (draft — environment blockers, not code):**
- Full live `vkdr devportal-platform install` on k3d (kubectl secret + kong + helm `--wait` + boot): the local WSL2 docker runtime wedged after repeated k3d cycles (cannot start containers); needs a docker/WSL restart to run.
- `mvn compile`: no JDK on the box and the project targets Java 25. The three command classes are 1:1 structural mirrors of the existing `VkdrDevPortalCommand`/install classes; CI build will compile them.

Marking ready once the live k3d e2e passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)